### PR TITLE
Add unprefixed transform & backface-visibility CSS

### DIFF
--- a/deckjs/themes/transition/horizontal-slide3d.css
+++ b/deckjs/themes/transition/horizontal-slide3d.css
@@ -32,16 +32,28 @@
       opacity: 0.4; }
   .csstransitions.csstransforms .deck-container:not(.deck-menu) > .deck-previous {
     -webkit-transform: rotateY(90deg) translate3d(0px, 0px, -4000px);
-    -webkit-backface-visibility: hidden; }
+    transform: rotateY(90deg) translate3d(0px, 0px, -4000px);
+    -webkit-backface-visibility: hidden;
+    backface-visibility: hidden;
+  }
   .csstransitions.csstransforms .deck-container:not(.deck-menu) > .deck-before {
     -webkit-transform: rotateY(90deg) translate3d(0px, 0px, -4000px);
-    -webkit-backface-visibility: hidden; }
+    transform: rotateY(90deg) translate3d(0px, 0px, -4000px);
+    -webkit-backface-visibility: hidden;
+    backface-visibility: hidden;    
+  }
   .csstransitions.csstransforms .deck-container:not(.deck-menu) > .deck-next {
     -webkit-transform: rotateY(-90deg) translate3d(0px, 0px, -4000px);
-    -webkit-backface-visibility: hidden; }
+    transform: rotateY(-90deg) translate3d(0px, 0px, -4000px);
+    -webkit-backface-visibility: hidden;
+    backface-visibility: hidden;
+  }
   .csstransitions.csstransforms .deck-container:not(.deck-menu) > .deck-after {
     -webkit-transform: rotateY(-90deg) translate3d(0px, 0px, -4000px);
-    -webkit-backface-visibility: hidden; }
+    transform: rotateY(-90deg) translate3d(0px, 0px, -4000px);
+    -webkit-backface-visibility: hidden;
+    backface-visibility: hidden;
+  }
   .csstransitions.csstransforms .deck-container:not(.deck-menu) > .deck-before .slide, .csstransitions.csstransforms .deck-container:not(.deck-menu) > .deck-previous .slide {
     visibility: visible; }
   .csstransitions.csstransforms .deck-container:not(.deck-menu) > .deck-child-current {


### PR DESCRIPTION
The slide hiding/showing in this presentation depends on these CSS classes, which currently only use webkit-prefixed CSS and are missing the standard unprefixed versions. So, the presentation doesn't work at all in Firefox 46 (or any other non-webkit-derived browser that doesn't include webkit prefixes for compatibility). All the slides are shown stacked on top of each other, in a jumble of letters.

This pull request adds the unprefixed syntax, which (based on local testing) fixes the issue in Firefox at least.
